### PR TITLE
TokenSpend webhook test (event-synced, closed)

### DIFF
--- a/.tokenspend-webhook-test.md
+++ b/.tokenspend-webhook-test.md
@@ -1,0 +1,1 @@
+TokenSpend event-driven sync test (P4). Safe to delete.


### PR DESCRIPTION
Proves pull_request webhooks update TokenSpend attribution with no manual sync. Will be closed right after.